### PR TITLE
Fixes typo for get number

### DIFF
--- a/scripts/tweets_grafo.py
+++ b/scripts/tweets_grafo.py
@@ -274,7 +274,7 @@ class Relation(object):
     return
                  
 def get_number (item):
-  numner=0
+  number=0
   match=(re.search (r"\d+",item))
   if match:
     number = int(match.group(0))


### PR DESCRIPTION
I fixed the typo "numner" by "number" after getting this error: `UnboundLocalError: local variable 'number' referenced before assignment` while creating a graph.